### PR TITLE
fix typo in linkedin link

### DIFF
--- a/src/components/data.js
+++ b/src/components/data.js
@@ -141,7 +141,7 @@ const initialDetails = [
   },
   {
     title: 'LinkedIn',
-    link: 'https://linkedin.com/loganliffick',
+    link: 'https://linkedin.com/in/loganliffick',
     category: social,
     new: false,
     divider: false,


### PR DESCRIPTION
Typo in your Linkedin link: https://linkedin.com/loganliffick/ => https://linkedin.com/in/loganliffick/ .
Very cool portfolio website btw :)